### PR TITLE
Group Selection Update + Bug Fixes

### DIFF
--- a/src/main/java/org/emrick/project/DrillParser.java
+++ b/src/main/java/org/emrick/project/DrillParser.java
@@ -120,7 +120,7 @@ public class DrillParser {
         LEDStrip l1 = new LEDStrip(drill.ledStrips.size(), 50, performer.getIdentifier() + "L", performer, true, -6, -6);
         drill.ledStrips.add(l1);
         performer.addLEDStrip(l1.getId());
-        LEDStrip l2 = new LEDStrip(drill.ledStrips.size(), 50, performer.getIdentifier() + "L", performer, true, 0, -6);
+        LEDStrip l2 = new LEDStrip(drill.ledStrips.size(), 50, performer.getIdentifier() + "L", performer, true, 1, -6);
         drill.ledStrips.add(l2);
         performer.addLEDStrip(l2.getId());
         return performer;

--- a/src/main/java/org/emrick/project/FootballFieldPanel.java
+++ b/src/main/java/org/emrick/project/FootballFieldPanel.java
@@ -207,9 +207,7 @@ public class FootballFieldPanel extends JPanel implements RepaintListener {
             double x = p.currentLocation.getX();
             double y = p.currentLocation.getY();
 
-//            if (selectedPerformers.containsKey(p.getSymbol() + p.getLabel())) {
-//                g.setColor(selectedPerformers.get(p.getSymbol() + p.getLabel()).getColor());
-//            }
+
             for (Integer i : p.getLedStrips()) {
                 LEDStrip l = drill.ledStrips.get(i);
 
@@ -228,16 +226,13 @@ public class FootballFieldPanel extends JPanel implements RepaintListener {
                 }
 
                 g.fillRect((int) x + l.gethOffset(), (int) y + l.getvOffset(), 6, 12);
+                if (selectedPerformers.get(p.getIdentifier()) != null) {
+                    g.setColor(Color.GREEN);
+                } else {
+                    g.setColor(Color.BLACK);
+                }
+                g.drawRect((int) x + l.gethOffset(), (int) y + l.getvOffset(), 6, 12);
             }
-
-            if (selectedPerformers.get(p.getIdentifier()) != null) {
-                g.setColor(Color.GREEN);
-            } else {
-                g.setColor(Color.BLACK);
-            }
-            g.drawRect((int)x-7,(int)y-7,14,14);
-            g.drawRect((int)x-6,(int)y-6,12,12);
-            g.drawLine((int)x,(int)y-5,(int)x,(int)y+6);
 
             if (showLabels) {
                 g.setFont(new Font("TimesRoman", Font.BOLD, (int) Math.ceil(fieldWidth / 120)));

--- a/src/main/java/org/emrick/project/MediaEditorGUI.java
+++ b/src/main/java/org/emrick/project/MediaEditorGUI.java
@@ -1943,7 +1943,7 @@ public class MediaEditorGUI extends Component implements ImportListener, ScrubBa
             ArrayList<LEDStrip> list7 = new ArrayList<>();
             for (int k = 0; k < footballFieldPanel.drill.ledStrips.size(); k++) {
                 LEDStrip l = footballFieldPanel.drill.ledStrips.get(k);
-                File curr = new File(PathConverter.pathConverter("tmp/" + l.getPerformerID()));
+                File curr = new File(PathConverter.pathConverter("tmp/" + l.getId()));
                 curr.createNewFile();
                 files.add(curr.getAbsolutePath());
 

--- a/src/main/java/org/emrick/project/SelectionGroupGUI.java
+++ b/src/main/java/org/emrick/project/SelectionGroupGUI.java
@@ -159,6 +159,9 @@ public class SelectionGroupGUI implements ActionListener {
 
     @Override
     public void actionPerformed(ActionEvent e) {
+        if ((ActionEvent.CTRL_MASK & e.getModifiers()) != 0) {
+
+        }
         for (SelectionGroup group : groups) {
             if (group.getTitleButton().equals(e.getSource())) {
 //                if(controlHeld) {

--- a/src/main/java/org/emrick/project/SelectionGroupGUI.java
+++ b/src/main/java/org/emrick/project/SelectionGroupGUI.java
@@ -159,18 +159,13 @@ public class SelectionGroupGUI implements ActionListener {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        if ((ActionEvent.CTRL_MASK & e.getModifiers()) != 0) {
-
-        }
         for (SelectionGroup group : groups) {
             if (group.getTitleButton().equals(e.getSource())) {
                 System.out.println(group.getTitle());
                 if((e.getModifiers() & ActionEvent.CTRL_MASK) != 0) {
                     selectListener.ctrlGroupSelection(group.performers);
-                    System.out.println("poop");
                 }
                 else{
-                    System.out.println("hm");
                     selectListener.onGroupSelection(group.performers);
                 }
             }

--- a/src/main/java/org/emrick/project/Unzip.java
+++ b/src/main/java/org/emrick/project/Unzip.java
@@ -52,6 +52,7 @@ public class Unzip {
                 int length;
                 while ((length = fis.read(bytes)) >= 0) {
                     zos.write(bytes, 0, length);
+                    zos.flush();
                 }
                 fis.close();
                 if (delete) {


### PR DESCRIPTION
You can now ctrl+click group buttons to deselect a group if they are all already selected. If any members of a group are not selected when ctrl clicking these buttons, they will be selected and other members will not be affected.

Fixed visual bug from displaying performers on some displays.

Fixed bug that caused program to crash when exporting packets